### PR TITLE
Update Invoke-GPOZaurrContent documentation and add new example

### DIFF
--- a/Docs/Invoke-GPOZaurrContent.md
+++ b/Docs/Invoke-GPOZaurrContent.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Invoke-GPOZaurrContent
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Invokes GPOZaurrContent function to retrieve Group Policy Objects information.
 
 ## SYNTAX
 
@@ -17,92 +17,45 @@ schema: 2.0.0
 Invoke-GPOZaurrContent [-Forest <String>] [-ExcludeDomains <String[]>] [-IncludeDomains <String[]>]
  [-ExtendedForestInformation <IDictionary>] [-Type <String[]>] [-Splitter <String>] [-FullObjects]
  [-OutputType <String[]>] [-OutputPath <String>] [-Open] [-Online] [-CategoriesOnly] [-SingleObject]
- [-SkipNormalize] [-SkipCleanup] [-Extended] [<CommonParameters>]
+ [-SkipNormalize] [-SkipCleanup] [-Extended] [-GPOName <String[]>] [-GPOGUID <String[]>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### Local
 ```
 Invoke-GPOZaurrContent [-GPOPath <String>] [-Type <String[]>] [-Splitter <String>] [-FullObjects]
  [-OutputType <String[]>] [-OutputPath <String>] [-Open] [-Online] [-CategoriesOnly] [-SingleObject]
- [-SkipNormalize] [-SkipCleanup] [-Extended] [<CommonParameters>]
+ [-SkipNormalize] [-SkipCleanup] [-Extended] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+This function retrieves Group Policy Objects information based on the specified parameters.
+It can search for GPOs in a forest, exclude specific domains, include specific domains, and provide extended forest information.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### EXAMPLE 1
+```
+Invoke-GPOZaurrContent -Forest "Contoso" -IncludeDomains "Domain1", "Domain2" -Type "Security" -OutputType "HTML" -OutputPath "C:\Reports\GPOReport.html"
+Retrieves security-related Group Policy Objects information for the specified domains and saves the output as an HTML file.
 ```
 
-{{ Add example description here }}
+### EXAMPLE 2
+```
+Invoke-GPOZaurrContent -GPOPath "CN={31B2F340-016D-11D2-945F-00C04FB984F9},CN=Policies,CN=System,DC=Contoso,DC=com" -Type "All" -OutputType "Object"
+Retrieves all information for a specific Group Policy Object and outputs the result as an object.
+```
+
+### EXAMPLE 3
+```
+Invoke-GPOZaurrContent -GPOName "Group Policy Test" -SingleObject | ConvertTo-Json -Depth 3
+Quickly view GPO settings by name in JSON format for easy inspection.
+```
 
 ## PARAMETERS
 
-### -CategoriesOnly
-{{ Fill CategoriesOnly Description }}
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ExcludeDomains
-{{ Fill ExcludeDomains Description }}
-
-```yaml
-Type: String[]
-Parameter Sets: Default
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Extended
-{{ Fill Extended Description }}
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ExtendedForestInformation
-{{ Fill ExtendedForestInformation Description }}
-
-```yaml
-Type: IDictionary
-Parameter Sets: Default
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Forest
-{{ Fill Forest Description }}
+Specifies the forest name to search for Group Policy Objects.
 
 ```yaml
 Type: String
@@ -116,27 +69,12 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -FullObjects
-{{ Fill FullObjects Description }}
+### -ExcludeDomains
+Specifies an array of domains to exclude from the search.
 
 ```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -GPOPath
-{{ Fill GPOPath Description }}
-
-```yaml
-Type: String
-Parameter Sets: Local
+Type: String[]
+Parameter Sets: Default
 Aliases:
 
 Required: False
@@ -147,7 +85,7 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeDomains
-{{ Fill IncludeDomains Description }}
+Specifies an array of domains to include in the search.
 
 ```yaml
 Type: String[]
@@ -161,12 +99,12 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Online
-{{ Fill Online Description }}
+### -ExtendedForestInformation
+Specifies additional information about the forest.
 
 ```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
+Type: IDictionary
+Parameter Sets: Default
 Aliases:
 
 Required: False
@@ -176,27 +114,12 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Open
-{{ Fill Open Description }}
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -OutputPath
-{{ Fill OutputPath Description }}
+### -GPOPath
+Specifies the path to a specific Group Policy Object.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: Local
 Aliases:
 
 Required: False
@@ -206,57 +129,11 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -OutputType
-{{ Fill OutputType Description }}
+### -Type
+Specifies the type of information to retrieve.
 
 ```yaml
 Type: String[]
-Parameter Sets: (All)
-Aliases:
-Accepted values: HTML, Object
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -SingleObject
-{{ Fill SingleObject Description }}
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -SkipCleanup
-{{ Fill SkipCleanup Description }}
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -SkipNormalize
-{{ Fill SkipNormalize Description }}
-
-```yaml
-Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
@@ -268,7 +145,52 @@ Accept wildcard characters: False
 ```
 
 ### -Splitter
-{{ Fill Splitter Description }}
+Specifies the delimiter to use for splitting information.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: [System.Environment]::NewLine
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FullObjects
+Indicates whether to retrieve full objects.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputType
+Specifies the type of output (HTML or Object).
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Object
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputPath
+Specifies the path to save the output.
 
 ```yaml
 Type: String
@@ -282,13 +204,149 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Type
-{{ Fill Type Description }}
+### -Open
+Indicates whether to open the output after retrieval.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Online
+Indicates whether to retrieve information online.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CategoriesOnly
+Indicates whether to retrieve only categories.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SingleObject
+When enabled, returns a single consolidated object per GPO rather than multiple objects for each setting. For example, with drive mappings, instead of returning separate objects for each mapped drive in a GPO, it will return one object containing all drive mappings for that GPO. This affects how the data is structured in the output reports.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipNormalize
+Indicates whether to skip normalization.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCleanup
+Indicates whether to skip cleanup of the output hashtable. When enabled, empty values in the output hashtable are preserved rather than being removed via Remove-EmptyValue. This parameter affects the final processing step before returning GPO analysis results.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Extended
+When enabled, returns the complete output hashtable containing all GPO analysis data, including both the processed reports and raw categories. By default, only the processed reports are returned. This parameter is useful for debugging or when you need access to the underlying data structure.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GPOName
+Specifies the name of the Group Policy Object to retrieve. The alias of this parameter is `Name`.
 
 ```yaml
 Type: String[]
-Parameter Sets: (All)
+Parameter Sets: Default
+Aliases: Name
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GPOGUID
+Specifies one or more Group Policy Object GUIDs to retrieve. This parameter allows you to target specific GPOs by their unique identifier rather than display name.
+
+
+```yaml
+Type: String[]
+Parameter Sets: Default
 Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+Specifies the action to take when progress is reported.
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
 
 Required: False
 Position: Named
@@ -302,11 +360,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
-
 ## OUTPUTS
 
-### System.Object
 ## NOTES
 
 ## RELATED LINKS

--- a/Public/Invoke-GPOZaurrContent.ps1
+++ b/Public/Invoke-GPOZaurrContent.ps1
@@ -59,6 +59,10 @@
     Invoke-GPOZaurrContent -GPOPath "CN={31B2F340-016D-11D2-945F-00C04FB984F9},CN=Policies,CN=System,DC=Contoso,DC=com" -Type "All" -OutputType "Object"
     Retrieves all information for a specific Group Policy Object and outputs the result as an object.
 
+    .EXAMPLE
+    Invoke-GPOZaurrContent -GPOName "Group Policy Test" -SingleObject | ConvertTo-Json -Depth 3
+    Quickly view GPO settings by name in JSON format for easy inspection.
+
     #>
     [alias('Find-GPO')]
     [cmdletBinding(DefaultParameterSetName = 'Default')]


### PR DESCRIPTION
- Enhance documentation for Invoke-GPOZaurrContent cmdlet with detailed parameter descriptions
- Add comprehensive parameter explanations and default values
- Include a new example demonstrating GPO retrieval by name with JSON conversion
- Update parameter set to include GPOName and GPOGUID parameters