### PR TITLE
[codex] self-contain AD administrative groups helper

### DIFF
--- a/Private/Get-ADAdministrativeGroups.ps1
+++ b/Private/Get-ADAdministrativeGroups.ps1
@@ -1,0 +1,73 @@
+﻿function Get-ADAdministrativeGroups {
+    <#
+    .SYNOPSIS
+    Retrieves administrative groups information from Active Directory.
+
+    .DESCRIPTION
+    Retrieves the Domain Admins and Enterprise Admins groups for the requested
+    forest and returns lookup dictionaries keyed by domain, NetBIOS name, and SID.
+
+    .PARAMETER Type
+    Specifies the type of administrative groups to retrieve. Valid values are
+    'DomainAdmins' and 'EnterpriseAdmins'.
+
+    .PARAMETER Forest
+    Specifies the name of the forest to query for administrative groups.
+
+    .PARAMETER ExcludeDomains
+    Specifies an array of domains to exclude from the query.
+
+    .PARAMETER IncludeDomains
+    Specifies an array of domains to include in the query.
+
+    .PARAMETER ExtendedForestInformation
+    Specifies additional information about the forest to include in the query.
+    #>
+    [cmdletBinding()]
+    param(
+        [parameter(Mandatory)][validateSet('DomainAdmins', 'EnterpriseAdmins')][string[]] $Type,
+        [alias('ForestName')][string] $Forest,
+        [string[]] $ExcludeDomains,
+        [alias('Domain', 'Domains')][string[]] $IncludeDomains,
+        [System.Collections.IDictionary] $ExtendedForestInformation
+    )
+
+    $ADDictionary = [ordered] @{
+        ByNetBIOS = [ordered] @{}
+        BySID     = [ordered] @{}
+    }
+
+    $ForestInformation = Get-WinADForestDetails -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
+
+    foreach ($Domain in $ForestInformation.Domains) {
+        $ADDictionary[$Domain] = [ordered] @{}
+        $QueryServer = $ForestInformation['QueryServers'][$Domain]['HostName'][0]
+        $DomainInformation = Get-ADDomain -Server $QueryServer
+
+        if ($Type -contains 'DomainAdmins') {
+            Get-ADGroup -Filter "SID -eq '$($DomainInformation.DomainSID)-512'" -Server $QueryServer -ErrorAction SilentlyContinue | ForEach-Object {
+                $ADDictionary['ByNetBIOS']["$($DomainInformation.NetBIOSName)\$($_.Name)"] = $_
+                $ADDictionary[$Domain]['DomainAdmins'] = "$($DomainInformation.NetBIOSName)\$($_.Name)"
+                $ADDictionary['BySID'][$_.SID.Value] = $_
+            }
+        }
+    }
+
+    foreach ($Domain in $ForestInformation.Forest.Domains) {
+        if (-not $ADDictionary[$Domain]) {
+            $ADDictionary[$Domain] = [ordered] @{}
+        }
+        if ($Type -contains 'EnterpriseAdmins') {
+            $QueryServer = $ForestInformation['QueryServers'][$Domain]['HostName'][0]
+            $DomainInformation = Get-ADDomain -Server $QueryServer
+
+            Get-ADGroup -Filter "SID -eq '$($DomainInformation.DomainSID)-519'" -Server $QueryServer -ErrorAction SilentlyContinue | ForEach-Object {
+                $ADDictionary['ByNetBIOS']["$($DomainInformation.NetBIOSName)\$($_.Name)"] = $_
+                $ADDictionary[$Domain]['EnterpriseAdmins'] = "$($DomainInformation.NetBIOSName)\$($_.Name)"
+                $ADDictionary['BySID'][$_.SID.Value] = $_
+            }
+        }
+    }
+
+    $ADDictionary
+}

--- a/Private/Get-PermissionsAnalysis.ps1
+++ b/Private/Get-PermissionsAnalysis.ps1
@@ -56,7 +56,7 @@
         [System.Collections.IDictionary] $ADAdministrativeGroups
     )
     if (-not $ADAdministrativeGroups) {
-        $ADAdministrativeGroups = Get-ADADministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
+        $ADAdministrativeGroups = Get-ADAdministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
     }
     $AdministrativeExists = [ordered] @{
         DisplayName      = $GPOPermissions[0].DisplayName

--- a/Public/Add-GPOZaurrPermission.ps1
+++ b/Public/Add-GPOZaurrPermission.ps1
@@ -91,7 +91,7 @@
     )
     $ForestInformation = Get-WinADForestDetails -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation -Extended
     if (-not $ADAdministrativeGroups) {
-        $ADAdministrativeGroups = Get-ADADministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
+        $ADAdministrativeGroups = Get-ADAdministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
     }
     if ($GPOName) {
         $Splat = @{

--- a/Public/Get-GPOZaurr.ps1
+++ b/Public/Get-GPOZaurr.ps1
@@ -88,7 +88,7 @@
     Begin {
         if (-not $ADAdministrativeGroups) {
             Write-Verbose "Get-GPOZaurr - Getting ADAdministrativeGroups"
-            $ADAdministrativeGroups = Get-ADADministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
+            $ADAdministrativeGroups = Get-ADAdministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
         }
         if (-not $GPOPath) {
             $ForestInformation = Get-WinADForestDetails -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation

--- a/Public/Get-GPOZaurrOwner.ps1
+++ b/Public/Get-GPOZaurrOwner.ps1
@@ -64,7 +64,7 @@
     Begin {
         $ForestInformation = Get-WinADForestDetails -Extended -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
         if (-not $ADAdministrativeGroups) {
-            $ADAdministrativeGroups = Get-ADADministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
+            $ADAdministrativeGroups = Get-ADAdministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
         }
         $Count = 0
     }

--- a/Public/Get-GPOZaurrPermission.ps1
+++ b/Public/Get-GPOZaurrPermission.ps1
@@ -115,7 +115,7 @@
     Begin {
         $ForestInformation = Get-WinADForestDetails -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation -Extended
         if (-not $ADAdministrativeGroups) {
-            $ADAdministrativeGroups = Get-ADADministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
+            $ADAdministrativeGroups = Get-ADAdministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
         }
         if ($Type -eq 'Unknown') {
             if ($SkipAdministrative -or $SkipWellKnown) {

--- a/Public/Get-GPOZaurrPermissionAnalysis.ps1
+++ b/Public/Get-GPOZaurrPermissionAnalysis.ps1
@@ -32,7 +32,7 @@
         [Array] $Permissions
     )
     if (-not $ADAdministrativeGroups) {
-        $ADAdministrativeGroups = Get-ADADministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
+        $ADAdministrativeGroups = Get-ADAdministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
     }
 
     if (-not $Permissions) {

--- a/Public/Invoke-GPOZaurrPermission.ps1
+++ b/Public/Invoke-GPOZaurrPermission.ps1
@@ -192,9 +192,9 @@
     $ForestInformation = Get-WinADForestDetails -Extended -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
     if ($LimitAdministrativeGroupsToDomain) {
         # This will get administrative based on IncludeDomains if given. It means that if GPO has Domain admins added from multiple domains it will only find one, and remove all other Domain Admins (if working with Domain Admins that is)
-        $ADAdministrativeGroups = Get-ADADministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ForestInformation
+        $ADAdministrativeGroups = Get-ADAdministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ForestInformation
     } else {
-        $ADAdministrativeGroups = Get-ADADministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest #-IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ForestInformation
+        $ADAdministrativeGroups = Get-ADAdministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest #-IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ForestInformation
     }
     if ($PSCmdlet.ParameterSetName -ne 'Level') {
         $Splat = @{

--- a/Public/Remove-GPOZaurrPermission.ps1
+++ b/Public/Remove-GPOZaurrPermission.ps1
@@ -85,7 +85,7 @@
     Begin {
         $Count = 0
         $ForestInformation = Get-WinADForestDetails -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
-        $ADAdministrativeGroups = Get-ADADministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ForestInformation
+        $ADAdministrativeGroups = Get-ADAdministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ForestInformation
         if ($Type -eq 'Unknown') {
             if ($SkipAdministrative -or $SkipWellKnown) {
                 Write-Warning "Remove-GPOZaurrPermission - Using SkipAdministrative or SkipWellKnown while looking for Unknown doesn't make sense as only Unknown will be displayed."

--- a/Public/Set-GPOZaurrOwner.ps1
+++ b/Public/Set-GPOZaurrOwner.ps1
@@ -97,7 +97,7 @@
         [switch] $Force
     )
     Begin {
-        $ADAdministrativeGroups = Get-ADADministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
+        $ADAdministrativeGroups = Get-ADAdministrativeGroups -Type DomainAdmins, EnterpriseAdmins -Forest $Forest -IncludeDomains $IncludeDomains -ExcludeDomains $ExcludeDomains -ExtendedForestInformation $ExtendedForestInformation
     }
     Process {
         $getGPOZaurrOwnerSplat = @{


### PR DESCRIPTION
## Summary
This change makes the AD administrative groups lookup self-contained within GPOZaurr.

## What Changed
- added a local private `Get-ADAdministrativeGroups` helper to GPOZaurr
- switched internal call sites from the deprecated external helper name to the local canonical helper
- removed the runtime dependence on the merged deprecated PSSharedGoods implementation for this path

## Why
Users reported `Invoke-GPOZaurr` failing with a missing administrative-groups helper in newer PSSharedGoods layouts.

## Root Cause
GPOZaurr still relied on an externally merged helper from PSSharedGoods. That helper lived in a deprecated location and exposed the typo'd name `Get-ADADministrativeGroups`, which made this path brittle across packaging and dependency changes.

## Impact
Owner and administrative-permission analysis paths in GPOZaurr now resolve their helper from the module itself, making the published module more reliable.

## Validation
- imported `GPOZaurr.psm1`
- verified `Get-ADAdministrativeGroups` is available from the module
- did not run a full AD-backed `Invoke-GPOZaurr` end-to-end test in this local environment
