### PR TITLE
Support Windows LAPS policies in LAPS report

### DIFF
--- a/Private/Script.GPODictionary.ps1
+++ b/Private/Script.GPODictionary.ps1
@@ -494,12 +494,15 @@
                 Settings = 'Policy'
             }
         )
-        GPOPath    = 'Policies -> Administrative Templates -> LAPS'
+        GPOPath    = @(
+            'Policies -> Administrative Templates -> LAPS'
+            'Policies -> Administrative Templates -> System -> LAPS'
+        )
         Code       = {
-            ConvertTo-XMLGenericPolicy -GPO $GPO -Category 'LAPS'
+            ConvertTo-XMLGenericPolicy -GPO $GPO -Category 'LAPS', 'System/LAPS*'
         }
         CodeSingle = {
-            ConvertTo-XMLGenericPolicy -GPO $GPO -Category 'LAPS' -SingleObject
+            ConvertTo-XMLGenericPolicy -GPO $GPO -Category 'LAPS', 'System/LAPS*' -SingleObject
         }
     }
     Lithnet                                         = @{

--- a/Tests/LAPSContent.Tests.ps1
+++ b/Tests/LAPSContent.Tests.ps1
@@ -1,0 +1,46 @@
+Describe 'LAPS content detection' {
+    BeforeAll {
+        Import-Module $PSScriptRoot\..\*.psd1 -Force
+    }
+
+    It 'LAPS dictionary supports legacy Microsoft LAPS and Windows LAPS categories' {
+        InModuleScope GPOZaurr {
+            $Entry = $Script:GPODitionary['LAPS']
+            $Entry.GPOPath | Should -Contain 'Policies -> Administrative Templates -> LAPS'
+            $Entry.GPOPath | Should -Contain 'Policies -> Administrative Templates -> System -> LAPS'
+            $Entry.Code.ToString() | Should -Match 'System/LAPS\*'
+            $Entry.CodeSingle.ToString() | Should -Match 'System/LAPS\*'
+        }
+    }
+
+    It 'ConvertTo-XMLGenericPolicy returns Windows LAPS policies from System/LAPS' {
+        InModuleScope GPOZaurr {
+            $GPO = [PSCustomObject] @{
+                DisplayName = 'Windows LAPS GPO'
+                DomainName  = 'contoso.com'
+                GUID        = '11111111-1111-1111-1111-111111111111'
+                GpoType     = 'Computer'
+                Linked      = $true
+                LinksCount  = 1
+                Links       = @('OU=Workstations,DC=contoso,DC=com')
+                DataSet     = @(
+                    [PSCustomObject] @{
+                        Category     = 'System/LAPS'
+                        Name         = 'Configure password backup directory'
+                        State        = 'Enabled'
+                        DropDownList = @(
+                            [PSCustomObject] @{
+                                Name  = 'Backup Directory'
+                                Value = 'Active Directory'
+                            }
+                        )
+                    }
+                )
+            }
+
+            $Result = ConvertTo-XMLGenericPolicy -GPO $GPO -Category 'LAPS', 'System/LAPS*'
+            $Result.ConfigurePasswordBackupDirectory | Should -Be 'Enabled'
+            $Result.ConfigurePasswordBackupDirectoryBackupDirectory | Should -Be 'Active Directory'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Windows LAPS (`System/LAPS*`) to the existing LAPS content report category matching
- keep legacy Microsoft LAPS (`LAPS`) support intact
- add focused Pester coverage for the dictionary entry and Windows LAPS policy conversion

## Root cause
The LAPS report only matched the legacy Administrative Templates category `LAPS`. Windows LAPS policies are reported under `System/LAPS`, so they were categorized but never selected by the LAPS report converter.

## Validation
- `pwsh -NoLogo -NoProfile -Command "Import-Module Pester -Force; Invoke-Pester -Path '.\Tests\LAPSContent.Tests.ps1' -Output Detailed"`
- `powershell -NoLogo -NoProfile -Command "Import-Module Pester -Force; Invoke-Pester -Path '.\Tests\LAPSContent.Tests.ps1' -Output Detailed"`
- `git diff --check`

Fixes #88