### PR TITLE
Fixed DateRange Filter

### DIFF
--- a/Public/Get-GPOZaurrAD.ps1
+++ b/Public/Get-GPOZaurrAD.ps1
@@ -119,7 +119,7 @@
                     $Splat['Filter'] = -join ($Splat['Filter'], ' -and ((WhenChanged -ge $DateFrom -and WhenChanged -le $DateTo) -or (WhenCreated -ge $DateFrom -and WhenCreated -le $DateTo))')
                 } elseif ($DateProperty -eq 'WhenChanged' -or $DateProperty -eq 'WhenCreated') {
                     $Property = $DateProperty[0]
-                    $Splat['Filter'] = -join ($Splat['Filter'], " -and ($Property -ge $DateFrom -and $Property -le $DateTo)")
+                    $Splat['Filter'] = -join ($Splat['Filter'], " -and ($Property -ge `$DateFrom -and $Property -le `$DateTo)")
                 } else {
                     Write-Warning -Message "Get-GPOZaurrAD - DateProperty parameter is empty. Provide name and try again."
                     continue
@@ -131,7 +131,7 @@
                     $Splat['Filter'] = -join ($Splat['Filter'], ' -and ((WhenChanged -ge $DateFrom -and WhenChanged -le $DateTo) -or (WhenCreated -ge $DateFrom -and WhenCreated -le $DateTo))')
                 } elseif ($DateProperty -eq 'WhenChanged' -or $DateProperty -eq 'WhenCreated') {
                     $Property = $DateProperty[0]
-                    $Splat['Filter'] = -join ($Splat['Filter'], " -and ($Property -ge $DateFrom -and $Property -le $DateTo)")
+                    $Splat['Filter'] = -join ($Splat['Filter'], " -and ($Property -ge `$DateFrom -and $Property -le `$DateTo)")
                 } else {
                     Write-Warning -Message "Get-GPOZaurrAD - DateProperty parameter is empty. Provide name and try again."
                     continue


### PR DESCRIPTION
Fixes Date Range filter from throwing this error:
Get-ADObject : Error parsing query: '(objectClass -eq 'groupPolicyContainer') -and (WhenCreated -ge 06/30/2026          00:00:00 -and WhenCreated -le 07/01/2026 00:00:00)' Error Message: 'Operator Not supported: ' at position: '66'.        At C:\Program Files\WindowsPowerShell\Modules\GPOZaurr\1.1.10\GPOZaurr.psm1:26199 char:24                               + ...  $Objects = Get-ADObject @Splat -Properties DisplayName, Name, Create ...                                         +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                 + CategoryInfo          : ParserError: (:) [Get-ADObject], ADFilterParsingException                                     + FullyQualifiedErrorId : ActiveDirectoryCmdlet:Microsoft.ActiveDirectory.Management.ADFilterParsingException,Micr     osoft.ActiveDirectory.Management.Commands.GetADObject